### PR TITLE
removes redundant line

### DIFF
--- a/index.md
+++ b/index.md
@@ -54,9 +54,6 @@ Data Carpentry's aim is to teach researchers basic concepts, skills, and tools f
 > 
 {: .prereq} 
 
-The workshop is taught using R.
-
-
 # Workshop Overview
 
 | Lesson    | Overview |


### PR DESCRIPTION
The workshop overview table immediately below this line makes clear that the workshop teaches R. No need to say so above. The short line all on its own looks weird.
