### PR TITLE
Update slack links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-[![DOI](https://zenodo.org/badge/124151544.svg)](https://zenodo.org/badge/latestdoi/124151544) [![Create a Slack Account with us](https://img.shields.io/badge/Create_Slack_Account-The_Carpentries-071159.svg)](https://swc-slack-invite.herokuapp.com/)
- [![Slack Status](https://img.shields.io/badge/Slack_Channel-dc--geospatial-E01563.svg)](https://swcarpentry.slack.com/messages/C9ME7G5RD)
+[![DOI](https://zenodo.org/badge/124151544.svg)](https://zenodo.org/badge/latestdoi/124151544) [![Create a Slack Account with us](https://img.shields.io/badge/Create_Slack_Account-The_Carpentries-071159.svg)](https://slack-invite.carpentries.org/)
+ [![Slack Status](https://img.shields.io/badge/Slack_Channel-dc--geospatial-E01563.svg)](https://carpentries.slack.com/messages/C9ME7G5RD)
 
 
 # Geospatial Workshop
 
-Overview of the Geospatial workshop. 
+Overview of the Geospatial workshop.
 
 ## Code of Conduct
 

--- a/bin/boilerplate/README.md
+++ b/bin/boilerplate/README.md
@@ -1,8 +1,8 @@
 # FIXME Lesson title
 
-[![Create a Slack Account with us](https://img.shields.io/badge/Create_Slack_Account-The_Carpentries-071159.svg)](https://swc-slack-invite.herokuapp.com/)
+[![Create a Slack Account with us](https://img.shields.io/badge/Create_Slack_Account-The_Carpentries-071159.svg)](https://slack-invite.carpentries.org/)
 
-This repository generates the corresponding lesson website from [The Carpentries](https://carpentries.org/) repertoire of lessons. 
+This repository generates the corresponding lesson website from [The Carpentries](https://carpentries.org/) repertoire of lessons.
 
 ## Contributing
 
@@ -17,12 +17,12 @@ Please see the current list of [issues][FIXME] for ideas for contributing to thi
 repository. For making your contribution, we use the GitHub flow, which is
 nicely explained in the chapter [Contributing to a Project](http://git-scm.com/book/en/v2/GitHub-Contributing-to-a-Project) in Pro Git
 by Scott Chacon.
-Look for the tag ![good_first_issue](https://img.shields.io/badge/-good%20first%20issue-gold.svg). This indicates that the maintainers will welcome a pull request fixing this issue.  
+Look for the tag ![good_first_issue](https://img.shields.io/badge/-good%20first%20issue-gold.svg). This indicates that the maintainers will welcome a pull request fixing this issue.
 
 
 ## Maintainer(s)
 
-Current maintainers of this lesson are 
+Current maintainers of this lesson are
 
 * FIXME
 * FIXME


### PR DESCRIPTION
The Carpentries recently updated their Slack domain URL and invite app URL. This PR updates the links to match the new domains.
